### PR TITLE
Fix: Use `Option<&T>` instead of `&Option<T>` for search field

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -197,7 +197,7 @@ mod test {
     #[test]
     fn test_extract_next_string() {
         let mut parser = EventReader::from_str(
-            r#"
+            r"
             <entry>
                 <ent_seq>1</ent_seq>
                 <k_ele>
@@ -215,7 +215,7 @@ mod test {
                     <field>country</field>
                 </sense>
             </entry>
-        "#,
+        ",
         );
 
         assert_eq!(extract_next_string(&mut parser), "1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ fn main() -> Result<()> {
             field,
             create_if_missing: _,
         } => {
-            let (searcher, top_docs) = search(&index, &schema, &term, &field)?;
+            let (searcher, top_docs) = search(&index, &schema, &term, field.as_ref())?;
 
             for (_score, doc_address) in top_docs {
                 let retrieved_doc = searcher.doc(doc_address)?;
@@ -210,7 +210,7 @@ fn search(
     index: &Index,
     schema: &Schema,
     term: &str,
-    field: &Option<Field>,
+    field: Option<&Field>,
 ) -> Result<(Searcher, Vec<(Score, DocAddress)>)> {
     let (word, reading, reading_romaji, meaning) = (
         schema.get_field("word").unwrap(),
@@ -226,10 +226,10 @@ fn search(
     let searcher = reader.searcher();
 
     let fields = match field {
-        Some(Field::Word) => vec![word],
-        Some(Field::Reading) => vec![reading],
-        Some(Field::ReadingRomaji) => vec![reading_romaji],
-        Some(Field::Meaning) => vec![meaning],
+        Some(&Field::Word) => vec![word],
+        Some(&Field::Reading) => vec![reading],
+        Some(&Field::ReadingRomaji) => vec![reading_romaji],
+        Some(&Field::Meaning) => vec![meaning],
         None => vec![word, reading, reading_romaji, meaning],
     };
 


### PR DESCRIPTION
This commit addresses a clippy lint `ref_option`, which suggests using `Option<&T>` over `&Option<T>` for better performance and idiomatic Rust.

The `search` function signature was changed from `field: &Option<Field>` to `field: Option<&Field>`. The function body and the call site in `main` were updated accordingly.

`cargo clippy --fix` and `cargo fmt` were run to apply the fix and ensure consistent formatting.